### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ purely.js
 .. image:: https://travis-ci.org/numerodix/purelyjs.png?branch=master
         :target: https://travis-ci.org/numerodix/purelyjs
 
-.. image:: https://pypip.in/license/purelyjs/badge.png
+.. image:: https://img.shields.io/pypi/l/purelyjs.svg
         :target: https://pypi.python.org/pypi/purelyjs/
 
 * Command line test runner with minimal hassle (only needs a javascript shell


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20purelyjs))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `purelyjs`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.